### PR TITLE
Ranked1v1 additions

### DIFF
--- a/faf/api/ranked1v1_schema.py
+++ b/faf/api/ranked1v1_schema.py
@@ -18,4 +18,4 @@ class Ranked1v1Schema(Schema):
     ranking = fields.Integer()
 
     class Meta:
-        type_ = 'ranked1v1'
+        type_ = 'rating'

--- a/faf/api/ranked1v1_schema.py
+++ b/faf/api/ranked1v1_schema.py
@@ -11,6 +11,8 @@ class Ranked1v1Schema(Schema):
     deviation = fields.Float()
     num_games = fields.Integer()
     won_games = fields.Integer()
+    lost_games = fields.Integer()
+    winning_percentage = fields.Float()
     is_active = fields.Boolean()
     rating = fields.Integer()
     ranking = fields.Integer()


### PR DESCRIPTION
I updated the ranking 1v1 schema to now support global rating. I am not sure if this is the correct way on handling this, but it should work. We may want to create two separate schemas (Ranked1v1 and GlobalRating). The `global_rating` table does not support `won_games` so you can't calculate the lost games or winning percentage off of it. I do think it would be nice to do this from now on, but maybe not needed.
