### PR TITLE
Turn off encoding in LuaRuntime from_lua

### DIFF
--- a/faf/tools/lua/parse.py
+++ b/faf/tools/lua/parse.py
@@ -13,7 +13,7 @@ try:
 
         fa_functions_path = pkg_resources.resource_filename('static', 'lua/fa_functions.lua')
 
-        lua = lupa.LuaRuntime()
+        lua = lupa.LuaRuntime(encoding=None)
         with open(fa_functions_path, 'r') as fp:
             lua.execute(fp.read())
 


### PR DESCRIPTION
When calling the `unfold_table` function, lupa would attempt to utf8-decode
everything, leading to a reproducable exception when it encounters some
garbage.

Test:
```
def unfold_table(t, seen=None):
    result = {}
    for k, v in t.items():
        if not lupa.lua_type(v):  # Already a python type
            print k, v
            result[k] = v
        elif lupa.lua_type(v) == 'table':
            print k
            result[k] = dict(v)
            print result[k]
    return result

import lupa

rt=lupa.LuaRuntime()
#rt=lupa.LuaRuntime(encoding=None)
rt.execute('a=1+1')
unfold_table(rt.globals())
```