### PR TITLE
Add faf-server-scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# faf-server-scripts
+Script collection for FAF server management
+
+There are Readme files in all the subfolders.

--- a/scripts/ban_player.sh
+++ b/scripts/ban_player.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-read -p "User to ban: " user
-read -p "Reason: " reason
-read -p "Expires at: " expiry
-
-echo "Banning user..."
-docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "insert into lobby_ban (idUser, reason, expires_at) values ((select id from login where login = '${user}'), '${reason}', '${expiry}') on duplicate key update reason='${reason}', expires_at='${expiry}';"
-echo "User banned."

--- a/scripts/featured_mods/README.md
+++ b/scripts/featured_mods/README.md
@@ -1,0 +1,127 @@
+# Featured Mod patch creation script
+
+## Featured Mod structure
+
+Featured mods consist of files that are downloaded either to `bin` or `gamedata`. Featured mod releases ("patches") are numbered sequentially. A full patchset at version `n` consists of all files that belong to the mod at the highest available version that is `<= n`.
+
+There are two tables in the db for every featured mod, `updates_<mod>` and `updated_<mod>_files`. The first one notes the filename and the path for the file. The second one has information about specific versions.
+
+There is also a content server that serves the files referenced in the db.
+
+Database example, for the nomads mod:
+
+```
+mysql> select * from updates_nomads;
++----+-------------------+----------+
+| id | filename          | path     |
++----+-------------------+----------+
+|  6 | init_nomads.lua   | bin      |
+|  9 | nomads_movies.nmd | gamedata |
+| 10 | effects.nmd       | gamedata |
+| 11 | env.nmd           | gamedata |
+| 12 | loc.nmd           | gamedata |
+| 13 | lua.nmd           | gamedata |
+| 14 | nomadhook.nmd     | gamedata |
+| 15 | nomads.nmd        | gamedata |
+| 16 | projectiles.nmd   | gamedata |
+| 17 | sounds.nmd        | gamedata |
+| 18 | units.nmd         | gamedata |
+| 19 | textures.nmd      | gamedata |
++----+-------------------+----------+
+12 rows in set (0.00 sec)
+
+mysql> describe updates_nomads_files;
++----------+----------------------+------+-----+---------+----------------+
+| Field    | Type                 | Null | Key | Default | Extra          |
++----------+----------------------+------+-----+---------+----------------+
+| id       | int(10) unsigned     | NO   | PRI | NULL    | auto_increment |
+| fileId   | smallint(5) unsigned | NO   | MUL | NULL    |                |
+| version  | int(11)              | NO   |     | NULL    |                |
+| name     | varchar(45)          | NO   |     | NULL    |                |
+| md5      | varchar(45)          | NO   |     | NULL    |                |
+| obselete | tinyint(1)           | NO   |     | 0       |                |
++----------+----------------------+------+-----+---------+----------------+
+6 rows in set (0.00 sec)
+
+```
+
+The query to get the current patchset is a handful:
+
+```
+mysql> select uf.* FROM (select fileId, MAX(version) as version from updates_nomads_files group by fileId) as maxthings inner join updates_nomads_files as uf on maxthings.fileId = uf.fileId and maxthings.version = uf.version;
++-----+--------+---------+-----------------------+----------------------------------+----------+
+| id  | fileId | version | name                  | md5                              | obselete |
++-----+--------+---------+-----------------------+----------------------------------+----------+
+| 127 |      6 |      61 | init_nomads.v61.lua   | c3f3ca8e9f1245114ca9f23ae471f8a7 |        0 |
+|  69 |      7 |      61 | nomads.v61.nmd        | 3b9a59ce008f8565b52782f9848b47a5 |        0 |
+|  14 |      8 |       2 | fafnomads.nmd         | 6a9b9dc8afbdd10f7c53a85680e538e1 |        0 |
+|  70 |      9 |      61 | nomads_movies.v61.nmd | 886615203eb636bc5ff0092a3cd9a3ba |        0 |
+| 128 |     10 |      61 | effects.v61.nmd       | b7050be45228a1aceda8ee6e59c191d8 |        0 |
+| 129 |     11 |      61 | env.v61.nmd           | 0a655f032da8466851a6382c4471d02c |        0 |
+| 130 |     12 |      61 | loc.v61.nmd           | 38f350b346d0621ccd97be8d87654694 |        0 |
+| 131 |     13 |      61 | lua.v61.nmd           | 0925ea1a650efd93be96cc3f63cab4a0 |        0 |
+| 132 |     14 |      61 | nomadhook.v61.nmd     | 40173a237850ec5fcd43d1233c053e9c |        0 |
+| 133 |     15 |      61 | nomads.v61.nmd        | f6ced953ac7ffbd634ebb07609d7a6f7 |        0 |
+| 134 |     16 |      61 | projectiles.v61.nmd   | 845a48fd9519008bc7eefc529930676d |        0 |
+| 135 |     17 |      61 | sounds.v61.nmd        | 0b4a9b5204f97de377647b6766fba200 |        0 |
+| 136 |     18 |      61 | units.v61.nmd         | acbea859d1e59e7a1f5a36e702704519 |        0 |
+| 137 |     19 |      61 | textures.v61.nmd      | b2ff198d454166f65ad9bcbecf2d61ea |        0 |
++-----+--------+---------+-----------------------+----------------------------------+----------+
+14 rows in set (0.01 sec)
+
+```
+
+To create a new patchset, the following things need to be done:
+
+1. Create the new files
+2. Compare new files with old files by checking md5sum
+3. Add files that changed to the db and copy them to the content server
+
+## Patch Info
+
+The `patch_info.json` file is necessary to tell the patch creation script (`make_patch.py`) which source files go into which pack.
+
+The structure is as follows:
+
+* mod: Defines which mod - put null there to require mod name being passed to `make_patch.py` on the commandline in case of mods that are deployed with multiple versions
+* version: mod version
+* files: List of filesets
+    * target filename, with `{}` placeholder for patch version
+    * file id for the file, corresponding to the `updates_<mod>` table
+    * source file - can be a single string, which means file is copied as-is, or a list of files and folders, which are zipped together
+
+Example:
+
+```
+{
+    "mod": "nomads",
+    "files": [
+        ["init_nomads.v{}.lua", 6, "init_nomads.lua"],
+        ["nomads_movies.v{}.nmd", 9, ["movies"]],
+        ["effects.v{}.nmd", 10, ["effects"]],
+        ["env.v{}.nmd", 11, ["env"]],
+        ["loc.v{}.nmd", 12, ["loc"]],
+        ["lua.v{}.nmd", 13, ["lua"]],
+        ["nomadhook.v{}.nmd", 14, ["nomadhook"]],
+        ["nomads.v{}.nmd", 15, ["nomads"]],
+        ["projectiles.v{}.nmd", 16, ["projectiles"]],
+        ["sounds.v{}.nmd", 17, ["sounds"]],
+        ["units.v{}.nmd", 18, ["units"]],
+        ["textures.v{}.nmd", 19, ["textures"]]
+    ]
+}
+```
+
+## Patch Creation Script
+
+The `make_patch.py` script is your one-stop shop to create a new patchset.
+
+**Important**: Run it with the cwd (current directory) set to the source repository of the mod you want to package.
+
+The script executes the following steps:
+
+* Parse arguments (run `make_patch.py -h` to get a list of accepted arguments)
+* Read the `patch_info.json` file
+* Get the current version of the mod files with their md5sums from the db
+* Make new mod files
+* For all mod files with a different md5sum, put the file in the content server directory and update the db

--- a/scripts/featured_mods/make_patch.py
+++ b/scripts/featured_mods/make_patch.py
@@ -1,0 +1,228 @@
+#!/usr/bin/python3
+
+"""
+  Mod updater script
+
+  This script packs up mod files, writes them to /opt/stable/content/faf/updaterNew/.../, and updates the database.
+
+  Code is mostly self-explanatory - read it from bottom to top.
+
+  Mod information is read from a `patch_info.json` file, check the sample file for its structure.
+
+"""
+
+import subprocess
+import shutil
+import hashlib
+import os
+import zipfile
+import tempfile
+import sys
+import json
+
+sys.path.append(os.path.abspath("/opt/stable/faftools/faf/tools"))
+from fa import update_version
+
+def read_db(mod):
+    """
+      Read latest versions and md5's from db
+    """
+    query = "select uf.fileId, uf.version, uf.name, uf.md5 FROM (select fileId, MAX(version) as version from updates_{mod}_files group by fileId) as maxthings inner join updates_{mod}_files as uf on maxthings.fileId = uf.fileId and maxthings.version = uf.version;".format(mod=mod)
+    table = subprocess.check_output(
+        "docker exec stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -sN -e '{}'".format(query),
+#            "docker exec -i stable_faf-db_1 mysql -u faf_lobby -pdD9J9zMvdCrLZF5Q faf_lobby -e '{}'".format(query),
+#            "docker exec -i stable_faf-db_1 mysql -u root -pZQ9t7nmEcUm3TJv6 faf_lobby -e '{}'".format(query),
+        shell=True
+    )
+    oldfiles = {}
+    for line in table.split('\n'):
+        if line != '':
+            fields = line.split('\t')
+            # key = fileId
+            oldfiles[int(fields[0])] = {
+                'version': fields[1],
+                'name': fields[2],
+                'md5': fields[3]
+            }
+    return oldfiles
+
+
+def update_db(mod, fileId, version, name, md5, dryrun):
+    queries = [
+        "DELETE FROM updates_{mod}_files WHERE fileId={fileId} AND version={version}".format(mod=mod, fileId=fileId, version=version),
+        "INSERT INTO updates_{mod}_files (fileId, version, name, md5, obselete) VALUES ({fileId}, {version}, \"{name}\", \"{md5}\", 0)".format(mod=mod, fileId=fileId, version=version, name=name, md5=md5)
+    ]
+    for query in queries:
+        print("Running " + query)
+        if not dryrun:
+            subprocess.check_call(
+                "docker exec stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e '{}'".format(query),
+    #            "docker exec -i stable_faf-db_1 mysql -u faf_lobby -pdD9J9zMvdCrLZF5Q faf_lobby -e '{}'".format(query),
+    #            "docker exec -i stable_faf-db_1 mysql -u root -pZQ9t7nmEcUm3TJv6 faf_lobby -e '{}'".format(query),
+                shell=True
+            )
+
+def calc_md5(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+def zipdir(path, ziph):
+    # ziph is zipfile handle
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            ziph.write(os.path.join(root, file))
+
+# FIXME: None of these shell calls are space-in-filenames safe
+def create_file(mod, fileId, version, name, source, target_dir, old_md5, dryrun):
+    target_dir = target_dir + '/updates_{}_files'.format(mod)
+    name = name.format(version)
+    target_name = target_dir + '/' + name
+    print("Processing {} (fileId {})".format(name, fileId))
+
+    # rename == False is for straight copy of source file
+    # rename == True is for moving a compiled file from its temporary location,
+    # which also means changing fname
+    rename = None
+    # list -> zipfile
+    if type(source) is list:
+        print("Zipping {} -> {}".format(source, target_name))
+        # make tempfile
+        fo, fname = tempfile.mkstemp('_' + name, 'patcher_')
+        zf = zipfile.ZipFile(os.fdopen(fo, 'w'), 'w', zipfile.ZIP_DEFLATED)
+        for sm in source:
+            zipdir(sm, zf)
+        zf.close()
+        rename = True
+    elif source.endswith('ForgedAlliance.exe'):
+        fo, fname = tempfile.mkstemp('_'+ name, 'patcher_')
+        fo.close() # Don't need the handle
+        update_version.update_exe_version(source, fname, version)
+        rename = True
+    else:
+        rename = False
+        fname = source
+
+    checksum = calc_md5(fname)
+    print('Compared checksums: Old {} New {}'.format(old_md5, checksum))
+
+    if checksum != old_md5:
+        print("Moving tempfile -> {}".format(target_name))
+        if not dryrun:
+            if rename:
+                os.rename(fname, target_name)
+            else:
+                shutil.copy(fname, target_name)
+        elif rename:
+            print('Dry run, not moving tempfile. Please delete {}.'.format(fname))
+    else:
+        print("New {} file is identical to current version - skipping update".format(name))
+        if rename:
+            if not dryrun:
+                os.unlink(fname)
+            else:
+                print('Dry run, not moving tempfile. Please delete {}.'.format(fname))
+
+    if not dryrun:
+        subprocess.call(
+            "chgrp www-data {f}; chmod 660 {f}".format(f=target_name),
+            shell=True
+        )
+
+    update_db(mod, fileId, version, name, checksum, dryrun)
+
+def do_files(mod, version, files, target_dir, dryrun):
+    # get old versions
+    current_files = read_db(mod)
+    for name, fileId, source in files:
+        create_file(mod, fileId, version, name, source, target_dir, current_files.get(fileId,{}).get('md5'), dryrun)
+
+if __name__ == '__main__':
+    import sys
+
+    args = sys.argv[1:]
+
+    dryrun = False
+    version = None
+    mod = None
+    usage = False
+    target_dir = '/opt/stable/content/faf/updaterNew/'
+    infofile = 'patch_info.json'
+    while len(args) > 0:
+        switch = args[0]
+        if switch[0] == '-':
+            if switch[1:] == 'n':
+                dryrun = True
+            elif switch[1:] == 'h':
+                usage = True
+            elif switch[1:] == 't':
+                target_dir = args.pop(1)
+            elif switch[1:] == 'i':
+                infofile = args.pop(1)
+            elif switch[1:] == 'm':
+                mod = args.pop(1)
+            else:
+                print('Unknown commandline switch {}'.format(switch))
+                usage=True
+                break
+        else:
+            try:
+                version = int(switch)
+            except:
+                print('Please pass a number for patch version')
+                usage=True
+                break
+        args.pop(0)
+
+    if usage:
+        print("""
+        Forged Alliance Forever featured mod patch compiler
+
+        This script takes information about an FAF featured mod and updates it.
+
+        Usage:
+
+        make_patch.py <patch> [switches]
+
+        Switches:
+        -h\tPrint usage information
+        -t DIR\tTarget dir for update files`
+        -i INFOFILE\tPatch info file
+        -n\tDry run (do not modify 'content' or db)
+        -f\tFull update (do not skip mod files that have same hash in last version)
+        """)
+        sys.exit(1)
+
+#    # target filename / fileId in updates_{mod}_files table / source files with version placeholder
+#    # if source files is single string, file is copied directly
+#    # if source files is a list, files are zipped
+#    files = [
+#        ('init_nomads.v{}.lua', 6, 'init_nomads.lua'),
+#        ('nomads_movies.v{}.nmd', 9, ['movies']),
+#        ('effects.v{}.nmd', 10, ['effects']),
+#        ('env.v{}.nmd', 11, ['env']),
+#        ('loc.v{}.nmd', 12, ['loc']),
+#        ('lua.v{}.nmd', 13, ['lua']),
+#        ('nomadhook.v{}.nmd', 14, ['nomadhook']),
+#        ('nomads.v{}.nmd', 15, ['nomads']),
+#        ('projectiles.v{}.nmd', 16, ['projectiles']),
+#        ('sounds.v{}.nmd', 17, ['sounds']),
+#        ('units.v{}.nmd', 18, ['units']),
+#        ('textures.v{}.nmd', 19, ['textures']),
+#    ]
+
+    with open(infofile) as fp:
+        info = json.load(fp)
+        mod is None:
+            mod = info['mod']
+        if version is None:
+            version = info['version']
+        files = info['files']
+
+    if mod is None or version is None:
+        print('Please pass mod name and version either via commandline or in info file.')
+        sys.exit(1)
+
+    do_files(mod, version, files, target_dir, dryrun)

--- a/scripts/featured_mods/patch_info.json
+++ b/scripts/featured_mods/patch_info.json
@@ -1,0 +1,17 @@
+{
+    "mod": "nomads",
+    "files": [
+        ["init_nomads.v{}.lua", 6, "init_nomads.lua"],
+        ["nomads_movies.v{}.nmd", 9, ["movies"]],
+        ["effects.v{}.nmd", 10, ["effects"]],
+        ["env.v{}.nmd", 11, ["env"]],
+        ["loc.v{}.nmd", 12, ["loc"]],
+        ["lua.v{}.nmd", 13, ["lua"]],
+        ["nomadhook.v{}.nmd", 14, ["nomadhook"]],
+        ["nomads.v{}.nmd", 15, ["nomads"]],
+        ["projectiles.v{}.nmd", 16, ["projectiles"]],
+        ["sounds.v{}.nmd", 17, ["sounds"]],
+        ["units.v{}.nmd", 18, ["units"]],
+        ["textures.v{}.nmd", 19, ["textures"]]
+    ]
+}

--- a/scripts/ladder/README.txt
+++ b/scripts/ladder/README.txt
@@ -1,0 +1,27 @@
+# ladder pool tool
+
+This directory contains a set of very hacky scripts intended to help with ladder pool maintenance.
+
+## get_ladder_maps.sh
+
+This is just a wrapper around the query
+
+    select lm.id, lm.idmap, mv.filename from ladder_map as lm join map_version as mv on lm.idmap = mv.id;
+
+It shows the current ladder maps with filename.
+
+## find_maps.sh
+
+Puts all arguments passed to a query searching for "filename LIKE '%$ARG%'" in the map_version table.
+
+This lets you quickly find maps by filename.
+
+## ladder_map_update.py
+
+Finds maps to add or remove by filename and shows table updates and query to do updates.
+
+Example usage:
+
+    ./ladder_map_update.py "+land_wilderness_v3.v0001" "+crashing_waves.v0005" "-land wilderness V2" "-crashing_waves.v0004"
+
+Use find_maps.sh to find/confirm filenames first.

--- a/scripts/ladder/find_maps.sh
+++ b/scripts/ladder/find_maps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+QUERY="select id, filename from map_version where "
+
+for arg in "$@"
+do
+  QUERY="$QUERY filename like '%$arg%' or"
+done
+
+QUERY="$QUERY 0=1;"
+
+echo $QUERY
+
+docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "$QUERY"

--- a/scripts/ladder/get_ladder_maps.sh
+++ b/scripts/ladder/get_ladder_maps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "select lm.id, lm.idmap, mv.filename from ladder_map as lm join map_version as mv on lm.idmap = mv.id;"

--- a/scripts/ladder/ladder_map_update.py
+++ b/scripts/ladder/ladder_map_update.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python2
+
+import subprocess
+import sys
+
+def get_curr_maps():
+    query = "docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -sN -e \"select lm.id, lm.idmap, mv.filename from ladder_map as lm join map_version as mv on lm.idmap = mv.id;\""
+    mapstable = subprocess.check_output(
+      query,
+      shell=True
+    )
+    ladder_maps = []
+    for line in mapstable.split('\n'):
+        ladder_maps.append(line.split('\t'))
+    return ladder_maps[:-1] # remove empty line
+
+def find_maps(filenames):
+    query = "select id, filename from map_version where "
+    query = query + ' or '.join(["filename LIKE 'maps/{}.zip'".format(fn) for fn in filenames])
+    print(query)
+    mapstable = subprocess.check_output(
+        "docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -sN -e \"{}\"".format(query),
+        shell=True
+    )
+    maps = []
+    for line in mapstable.split('\n'):
+        maps.append(line.split('\t'))
+    return maps[:-1]
+
+def make_query(addmaps, outmaps):
+    if len(addmaps) > 0:
+        add_query = "INSERT INTO ladder_map (idmap) VALUES {};".format(
+            ', '.join(['({})'.format(row[0]) for row in addmaps])
+        )
+        print(add_query)
+    else:
+        print('no maps to add!')
+
+    if len(outmaps) > 0:
+        delete_query = "DELETE FROM ladder_map WHERE {};".format(
+            ' OR '.join(['id={}'.format(row[0]) for row in outmaps])
+        )
+        print(delete_query)
+    else:
+        print('no maps to delete!')
+
+
+def print_ladder_maps(maps):
+    print("\n".join(["\t".join(row) for row in maps]))
+
+if __name__=='__main__':
+    addmaps = []
+    outmaps = []
+  
+    for arg in sys.argv[1:]:
+        if arg.startswith('-'):
+            outmaps.append(arg[1:])
+        elif arg.startswith('+'):
+            addmaps.append(arg[1:])
+        else:
+            print("Erroneous arg")
+            sys.exit(1)
+
+    curr_maps = get_curr_maps()
+    print(curr_maps)
+
+    if len(addmaps) > 0:
+            addmaps = find_maps(addmaps)
+    if len(outmaps) > 0:
+            outmaps = find_maps(outmaps)
+
+    print("Maps to remove:")
+    print("id\tfilename")
+    print_ladder_maps(outmaps)
+
+    print("Maps to add:")
+    print("id\tfilename")
+    print_ladder_maps(addmaps)
+
+    curr_map_ids = [map[1] for map in curr_maps]
+    add_map_ids = [map[0] for map in addmaps]
+    out_map_ids = [map[0] for map in outmaps]
+
+#    print("Current ladder maps:")
+#    print("id\tidmap\tfilename")
+#    print_ladder_maps(curr_maps)
+
+    real_addmaps = []
+    real_outmaps = []
+
+    new_maps = []
+    for row in curr_maps:
+        if row[1] not in out_map_ids:
+            new_maps.append(['  '] + row)
+        else:
+            new_maps.append(['--'] + row)
+            real_outmaps.append(row)
+
+    for row in addmaps:
+        if row[0] not in curr_map_ids:
+                new_maps.append(['++','??'] + row)
+                real_addmaps.append(row)
+
+    print("New ladder maps:")
+    print("diff\tid\tidmap\tfilename")
+    print_ladder_maps(new_maps)
+
+    make_query(real_addmaps, real_outmaps)

--- a/scripts/misc/created_launched_games.py
+++ b/scripts/misc/created_launched_games.py
@@ -1,0 +1,42 @@
+# Get raw data using:
+# grep -F 'CustomGame' /var/log/syslog | grep 'created\|launched' > /tmp/game_create_launch_time
+# Then pipe to this script
+
+import sys
+import datetime
+
+months = {
+'Jan':1,
+'Feb':2,
+'Mar': 3,
+'Apr':4,
+'May':5,
+'Jun':6,
+'Jul':7,
+'Aug':8,
+'Sep':9,
+'Oct':10,
+'Nov':11,
+'Dec':12
+}
+
+games = {}
+
+for line in sys.stdin.readlines():
+  comps = line.split()
+  month = months[comps[0]]
+  day = int(comps[1])
+  tm = [int(x) for x in comps[2].split(':')]
+  game_id = comps[6]
+  action = comps[-1]
+  dt = datetime.datetime(year=2017, month=month, day=day, hour=tm[0], minute=tm[1], second=tm[2])
+  game = games.get(game_id, {})
+  game[action] = dt
+  games[game_id] = game
+
+for game_id, game_info in games.items():
+  if 'created' in game_info and 'launched' in game_info:
+    created = game_info['created']
+    launched = game_info['launched']
+    span = launched - created
+    print("{};{};{};{}".format(game_id, created, launched, span))

--- a/scripts/misc/zipgrep.sh
+++ b/scripts/misc/zipgrep.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+TERM="$1"
+shift
+
+while (( "$#" )); do
+
+    if ( unzip -l "$1" | grep -q "$TERM"); then
+        echo "$1"
+    fi
+
+    shift
+done

--- a/scripts/moderation/ban.sh
+++ b/scripts/moderation/ban.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PLAYER=$1
+AUTHOR=$2
+REASON=$3
+TMS=$4
+
+QUERY="insert into ban (player_id, author_id, reason, expires_at, level) select (select id from login where login='$PLAYER'), (select id from login where login='$AUTHOR'), '$REASON',  DATE_ADD(NOW(), INTERVAL $TMS), 'GLOBAL';"
+
+echo "$QUERY"
+docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "$QUERY"

--- a/scripts/moderation/email.sh
+++ b/scripts/moderation/email.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+QUERY="SELECT l.id,l.login,l.password,l.email,l.ip,l.steamid,l.update_time,b.expires_at FROM login l left join ban b on (b.player_id = l.id) where l.email regexp '^[a-z]{3}[0-9]{5}@'order by l.update_time asc;"
+
+echo "$QUERY"
+docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "$QUERY" | tail -n 50

--- a/scripts/moderation/email_list.sh
+++ b/scripts/moderation/email_list.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+QUERY="SELECT l.email FROM login l where l.email regexp '^[a-z]{3}[0-9]{5}@';"
+
+echo "$QUERY"
+docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "$QUERY" | grep -o '@.*$' | sort | uniq -c | sort -g

--- a/scripts/moderation/uuid.sh
+++ b/scripts/moderation/uuid.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#QUERY="SELECT l.id,l.login,l.password,l.email,l.update_time,b.expires_at FROM login l left join ban b on (b.player_id = l.id) where l.email regexp '^[a-z]{3}[0-9]{5}@'order by l.update_time asc;"
+QUERY="select distinct l.login, l.email, l.update_time, ui.hash, b.expires_at  from uniqueid ui join unique_id_users uiu on (ui.hash = uiu.uniqueid_hash) join login l on (l.id = uiu.user_id) left join ban b on (b.player_id = l.id) where ui.uuid regexp '^[A-Z-]*$' and ui.mem_SerialNumber regexp '^[A-Z-]*$' order by l.update_time desc limit 100;"
+
+echo "$QUERY"
+docker exec -i stable_faf-db_1 mysql --login-path=faf_lobby faf_lobby -e "$QUERY"


### PR DESCRIPTION
Simple, mostly stupid scripts for actions/maintenance on the server

I made my own repo for this but then I realized there's already a scripts folder in faftools.

TODO:
* Make sure they're all python3
* Update them with various tweaks made directly on the server

Possible improvements:
* Remove the `docker exec` calls and use proper mysql connection instead