### PR TITLE
parse_mod_info: Filter empty strings to marshmallow doesn't get angry

### DIFF
--- a/faf/tools/fa/mods.py
+++ b/faf/tools/fa/mods.py
@@ -47,6 +47,8 @@ def parse_mod_info(zip_file_or_folder):
     else:
         raise ValueError("Not a directory nor a file: " + str(zip_file_or_folder))
 
+    lua_data = {k: v for k, v in lua_data.items() if v is not None and v is not ""}
+
     data, errors = ModInfoSchema().load(dict(lua_data))
     if errors:
         raise ValueError(errors)

--- a/faf/tools/lua/parse.py
+++ b/faf/tools/lua/parse.py
@@ -3,7 +3,6 @@ import pkg_resources
 try:
     import lupa
 
-
     def from_lua(lua_code):
         """
         Use Lupa as a parser by actually running the code
@@ -14,18 +13,23 @@ try:
         fa_functions_path = pkg_resources.resource_filename('static', 'lua/fa_functions.lua')
 
         lua = lupa.LuaRuntime()
+        # we don't care about all of the "internal" globals
+        # especially not the ones that contain binary stuff
+        # resulting in UnicodeDecodeError when we try to unfold them
+        default_globals = dict(lua.globals()).keys()
         with open(fa_functions_path, 'r') as fp:
             lua.execute(fp.read())
 
         lua.execute(lua_code)
 
-        def unfold_table(t, seen=None):
+        def unfold_table(t):
             result = {}
             for k, v in t.items():
-                if not lupa.lua_type(v):  # Already a python type
-                    result[k] = v
-                elif lupa.lua_type(v) == 'table':
-                    result[k] = dict(v)
+                if k not in default_globals:
+                    if not lupa.lua_type(v):  # Already a python type
+                        result[k] = v
+                    elif lupa.lua_type(v) == 'table':
+                        result[k] = dict(v)
             return result
 
         return unfold_table(lua.globals())


### PR DESCRIPTION
marshmallow does not like empty strings in `UrlField`s and therefore failed validation if a `mod_info.lua` contained `url = ""`.

This commit removes all `None` and `""` values from the data before passing it to the marshmallow schema.

Fixes #31

Also contains a lua fix:

Ignore "internal" globals when parsing lua: When we execute lua scripts to extract the global variables they set, we are not interested in the things that already hang around in the globals table when the Lua VM is initialized.

Since these things also contain binary that we don't want to run through string decoding (resulting in `UnicodeDecodeError`), we're better off getting rid of them.

